### PR TITLE
Convert hostname to IP when getting distance

### DIFF
--- a/server/router.go
+++ b/server/router.go
@@ -888,7 +888,20 @@ func (r *LatencyRouter) GetDistanceFromB(ctx context.Context, orch_ip string, b_
 	}
 	defer db.Close()
 
+	//if the IP is a hostname, then get the IP.
 	o_ip := gonet.ParseIP(orch_ip)
+	if o_ip == nil {
+		ips, err := gonet.LookupIP(orch_ip)
+		if err != nil {
+			glog.Infof("%v  failed to lookup IP for orch ip %v", b_ip, orch_ip)
+			glog.Error(err)
+		}
+		if len(ips) > 0 {
+			o_ip = ips[0]
+			glog.Infof("DNS name: got IP %s for %s", ips[0], orch_ip)
+		}
+	}
+
 	o_record, err := db.City(o_ip)
 	if err != nil {
 		glog.Infof("%v  failed to parse orch ip for geo distance calc  %v", b_ip, orch_ip)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Allows hostnames to be used as orchAddr with geo routing. 

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- When getting distance from O to B, attempts to resolve hostname to an IP when IP parsing fails. Only uses IP for geo distance lookup 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added log message and deployed with a hostname in orchAddr flag

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./doc/contributing.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
