### PR TITLE
server: single-shot payment review follow-ups

### DIFF
--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -45,7 +45,6 @@ const maxLiveRunnerTrickleChannelsPerRequest = 25
 const liveRunnerSenderHeader = "Livepeer-Payer-Address"
 const liveRunnerSessionIDHeader = "Livepeer-Session-Id"
 const liveRunnerSessionControlHeader = "Livepeer-Session-Control"
-const liveRunnerSessionPaymentHeader = "Livepeer-Session-Payment"
 const maxScopeRequestBodySize = 1 << 20 // 1 MB
 
 func startAIServer(lp *lphttp) error {
@@ -184,6 +183,8 @@ type liveRunnerPaymentChallengeResponse struct {
 	// Keep the URL in top-level JSON so clients do not need to parse the protobuf just to route payment.
 	Orchestrator string `json:"orchestrator"`
 	ManifestID   string `json:"manifest_id"`
+	// Interval at which the orchestrator debits the session balance.
+	PaymentIntervalMs int64 `json:"payment_interval_ms"`
 }
 
 type liveRunnerTrickleChannelRequest struct {
@@ -258,7 +259,7 @@ func (h *lphttp) ReserveLiveRunnerSession(w http.ResponseWriter, r *http.Request
 			respondWithError(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		h.startLiveRunnerSessionPaymentMonitor(ctx, manager, runnerID, sessionID, payment, string(segData.ManifestID))
+		h.startLiveRunnerSessionPaymentLoop(ctx, manager, runnerID, sessionID, payment, segData.ManifestID)
 	}
 	controlURL := h.orchestrator.ServiceURI().JoinPath("apps", runnerID, "session", sessionID).String()
 	appURL := h.orchestrator.ServiceURI().JoinPath("apps", runnerID, "session", sessionID, "app").String()
@@ -281,7 +282,7 @@ func (h *lphttp) runnerChallenge(w http.ResponseWriter, r *http.Request, priceIn
 		respondWithError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	data, err := marshalLivePaymentChallengeResponse(oInfo)
+	data, err := marshalLivePaymentChallengeResponse(oInfo, h.node.LivePaymentInterval)
 	if err != nil {
 		respondWithError(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -306,7 +307,7 @@ func (h *lphttp) scopePaymentChallenge(w http.ResponseWriter, r *http.Request) (
 	if err != nil {
 		return false, err
 	}
-	data, err := marshalLivePaymentChallengeResponse(oInfo)
+	data, err := marshalLivePaymentChallengeResponse(oInfo, h.node.LivePaymentInterval)
 	if err != nil {
 		return false, err
 	}
@@ -316,15 +317,16 @@ func (h *lphttp) scopePaymentChallenge(w http.ResponseWriter, r *http.Request) (
 	return true, nil
 }
 
-func marshalLivePaymentChallengeResponse(oInfo *lpnet.OrchestratorInfo) ([]byte, error) {
+func marshalLivePaymentChallengeResponse(oInfo *lpnet.OrchestratorInfo, paymentInterval time.Duration) ([]byte, error) {
 	buf, err := proto.Marshal(oInfo)
 	if err != nil {
 		return nil, err
 	}
 	return json.Marshal(liveRunnerPaymentChallengeResponse{
-		PaymentParams: base64.StdEncoding.EncodeToString(buf),
-		Orchestrator:  oInfo.GetTranscoder(),
-		ManifestID:    oInfo.GetAuthToken().GetSessionId(),
+		PaymentParams:     base64.StdEncoding.EncodeToString(buf),
+		Orchestrator:      oInfo.GetTranscoder(),
+		ManifestID:        oInfo.GetAuthToken().GetSessionId(),
+		PaymentIntervalMs: paymentInterval.Milliseconds(),
 	})
 }
 
@@ -656,7 +658,7 @@ func (h *lphttp) ProxyLiveRunnerSingleShot(w http.ResponseWriter, r *http.Reques
 			respondWithError(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		h.startLiveRunnerSessionPaymentMonitor(ctx, manager, runnerID, sessionID, payment, string(segData.ManifestID))
+		h.startLiveRunnerSessionPaymentLoop(ctx, manager, runnerID, sessionID, payment, segData.ManifestID)
 	}
 
 	sessionToken, err := manager.SessionTokenForSession(runnerID, sessionID)
@@ -681,7 +683,6 @@ func (h *lphttp) proxyLiveRunner(w http.ResponseWriter, r *http.Request, runnerI
 		return
 	}
 	sessionControlURL := liveRunnerURI(h.node, h.orchestrator).JoinPath("runner", runnerID, "session", sessionID).String()
-	sessionPaymentURL := h.orchestrator.ServiceURI().JoinPath("apps", runnerID, "session", sessionID, "payment").String()
 	proxy := &httputil.ReverseProxy{
 		Rewrite: func(req *httputil.ProxyRequest) {
 			req.Out.URL.Scheme = target.Scheme
@@ -695,12 +696,6 @@ func (h *lphttp) proxyLiveRunner(w http.ResponseWriter, r *http.Request, runnerI
 			req.Out.Header.Set("Livepeer-Session-Token", sessionToken)
 			req.Out.Header.Set(liveRunnerSessionControlHeader, sessionControlURL)
 		},
-		ModifyResponse: func(resp *http.Response) error {
-			resp.Header.Set(liveRunnerSessionIDHeader, sessionID)
-			resp.Header.Set(liveRunnerSessionControlHeader, sessionControlURL)
-			resp.Header.Set(liveRunnerSessionPaymentHeader, sessionPaymentURL)
-			return nil
-		},
 		ErrorHandler: func(w http.ResponseWriter, req *http.Request, err error) {
 			respondWithError(w, err.Error(), http.StatusBadGateway)
 		},
@@ -708,27 +703,27 @@ func (h *lphttp) proxyLiveRunner(w http.ResponseWriter, r *http.Request, runnerI
 	proxy.ServeHTTP(w, r)
 }
 
-func (h *lphttp) startLiveRunnerSessionPaymentMonitor(ctx context.Context, manager liveRunnerManager, runnerID, sessionID string, payment lpnet.Payment, manifestID string) {
-	monitorCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+func (h *lphttp) startLiveRunnerSessionPaymentLoop(ctx context.Context, manager liveRunnerManager, runnerID, sessionID string, payment lpnet.Payment, manifestID core.ManifestID) {
+	loopCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	paymentReceiver := livePaymentReceiver{orchestrator: h.orchestrator}
 	accountPaymentFunc := func(inPixels int64) error {
-		err := paymentReceiver.AccountPayment(monitorCtx, &SegmentInfoReceiver{
+		err := paymentReceiver.AccountPayment(loopCtx, &SegmentInfoReceiver{
 			sender:    getPaymentSender(payment),
 			inPixels:  inPixels,
 			priceInfo: payment.GetExpectedPrice(),
-			sessionID: manifestID,
+			sessionID: string(manifestID),
 		})
 		if err != nil {
-			clog.Errorf(monitorCtx, "Error accounting live runner payment, releasing session err=%v", err)
+			clog.Errorf(loopCtx, "Error accounting live runner payment, releasing session err=%v", err)
 			if releaseErr := manager.ReleaseSession(runnerID, sessionID); releaseErr != nil {
-				clog.Errorf(monitorCtx, "Error releasing live runner session after payment failure err=%v", releaseErr)
+				clog.Errorf(loopCtx, "Error releasing live runner session after payment failure err=%v", releaseErr)
 			}
 			// Stop both the ticker loop below and the LivePaymentProcessor goroutine.
 			cancel()
 		}
 		return err
 	}
-	paymentProcessor := NewLivePaymentProcessor(monitorCtx, h.node.LivePaymentInterval, accountPaymentFunc)
+	paymentProcessor := NewLivePaymentProcessor(loopCtx, h.node.LivePaymentInterval, accountPaymentFunc)
 	go func() {
 		ticker := time.NewTicker(h.node.LivePaymentInterval)
 		defer ticker.Stop()
@@ -736,13 +731,13 @@ func (h *lphttp) startLiveRunnerSessionPaymentMonitor(ctx context.Context, manag
 		for {
 			select {
 			case <-ticker.C:
-				// Stop monitoring once the live runner session has been released
+				// Stop the loop once the live runner session has been released
 				// by an explicit stop, runner cleanup, expiry, or payment failure.
 				if _, err := manager.RunnerEndpointForSession(runnerID, sessionID); err != nil {
 					return
 				}
-				paymentProcessor.process(monitorCtx)
-			case <-monitorCtx.Done():
+				paymentProcessor.process(loopCtx)
+			case <-loopCtx.Done():
 				return
 			}
 		}

--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -617,11 +617,10 @@ func (h *lphttp) ProxyLiveRunnerSingleShot(w http.ResponseWriter, r *http.Reques
 	}
 
 	var (
-		payment         lpnet.Payment
-		segData         *core.SegTranscodingMetadata
-		ctx             = clog.AddVal(r.Context(), "runner_id", runnerID)
-		reservedID      string
-		reservedIDInput string
+		payment   lpnet.Payment
+		segData   *core.SegTranscodingMetadata
+		ctx       = r.Context()
+		sessionID string
 	)
 	if paymentRequired {
 		var err error
@@ -633,31 +632,27 @@ func (h *lphttp) ProxyLiveRunnerSingleShot(w http.ResponseWriter, r *http.Reques
 			respondWithError(w, "mismatched manifest and auth token", http.StatusForbidden)
 			return
 		}
-		reservedIDInput = string(segData.ManifestID)
+		// for easier correlation across orch, gw, signer
+		sessionID = string(segData.ManifestID)
 	}
-
-	sessionID, endpoint, err := manager.ReserveSession(runnerID, reservedIDInput)
+	sessionID, endpoint, err := manager.ReserveSession(runnerID, sessionID)
 	if err != nil {
 		respondWithLiveRunnerError(w, err)
 		return
 	}
-	reservedID = sessionID
-	ctx = clog.AddVal(ctx, "session_id", sessionID)
+
+	// Release on return: a single-shot session lives for exactly one request.
 	defer func() {
-		if reservedID == "" {
-			return
-		}
-		if err := manager.ReleaseSession(runnerID, reservedID); err != nil {
+		if err := manager.ReleaseSession(runnerID, sessionID); err != nil {
 			slog.Error("error releasing single-shot session", "runner_id", runnerID, "session_id", sessionID, "err", err)
 		}
 	}()
 
+	ctx = clog.AddVal(r.Context(), "runner_id", runnerID)
+	ctx = clog.AddVal(ctx, "session_id", sessionID)
 	if paymentRequired {
-		if string(segData.ManifestID) != sessionID {
-			respondWithError(w, "mismatched session and payment manifest", http.StatusForbidden)
-			return
-		}
 		if err := h.orchestrator.ProcessPayment(ctx, payment, segData.ManifestID); err != nil {
+			// Session released by the defer above.
 			respondWithError(w, err.Error(), http.StatusBadRequest)
 			return
 		}
@@ -669,6 +664,7 @@ func (h *lphttp) ProxyLiveRunnerSingleShot(w http.ResponseWriter, r *http.Reques
 		respondWithLiveRunnerError(w, err)
 		return
 	}
+
 	h.proxyLiveRunner(w, r, runnerID, sessionID, sessionToken, endpoint)
 }
 

--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -259,7 +259,8 @@ func (h *lphttp) ReserveLiveRunnerSession(w http.ResponseWriter, r *http.Request
 			respondWithError(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		h.startLiveRunnerSessionPaymentLoop(ctx, manager, runnerID, sessionID, payment, segData.ManifestID)
+		// Detach from the request ctx so the loop outlives this reservation call.
+		h.startLiveRunnerSessionPaymentLoop(context.WithoutCancel(ctx), manager, runnerID, sessionID, payment, segData.ManifestID)
 	}
 	controlURL := h.orchestrator.ServiceURI().JoinPath("apps", runnerID, "session", sessionID).String()
 	appURL := h.orchestrator.ServiceURI().JoinPath("apps", runnerID, "session", sessionID, "app").String()
@@ -658,6 +659,7 @@ func (h *lphttp) ProxyLiveRunnerSingleShot(w http.ResponseWriter, r *http.Reques
 			respondWithError(w, err.Error(), http.StatusBadRequest)
 			return
 		}
+		// Bound to the request ctx so the loop ends when this single-shot call returns.
 		h.startLiveRunnerSessionPaymentLoop(ctx, manager, runnerID, sessionID, payment, segData.ManifestID)
 	}
 
@@ -703,8 +705,10 @@ func (h *lphttp) proxyLiveRunner(w http.ResponseWriter, r *http.Request, runnerI
 	proxy.ServeHTTP(w, r)
 }
 
+// startLiveRunnerSessionPaymentLoop starts the metering loop; the caller controls
+// its lifetime via the ctx it passes.
 func (h *lphttp) startLiveRunnerSessionPaymentLoop(ctx context.Context, manager liveRunnerManager, runnerID, sessionID string, payment lpnet.Payment, manifestID core.ManifestID) {
-	loopCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	loopCtx, cancel := context.WithCancel(ctx)
 	paymentReceiver := livePaymentReceiver{orchestrator: h.orchestrator}
 	accountPaymentFunc := func(inPixels int64) error {
 		err := paymentReceiver.AccountPayment(loopCtx, &SegmentInfoReceiver{

--- a/server/ai_http_test.go
+++ b/server/ai_http_test.go
@@ -1304,9 +1304,6 @@ func TestLiveRunnerSingleShotProxyForwardsAndReleasesCapacity(t *testing.T) {
 	require.Equal(t, http.StatusAccepted, w.Code)
 	require.Equal(t, "single-shot", w.Body.String())
 	require.Equal(t, "ok", w.Header().Get("X-Upstream"))
-	require.Equal(t, gotSessionID, w.Header().Get(liveRunnerSessionIDHeader))
-	require.Equal(t, gotSessionControl, w.Header().Get(liveRunnerSessionControlHeader))
-	require.Equal(t, "http://localhost:1234/apps/runner-1/session/"+gotSessionID+"/payment", w.Header().Get(liveRunnerSessionPaymentHeader))
 	require.Equal(t, "/base/v1/foo/bar", gotPath)
 	require.Equal(t, "x=1&y=two", gotQuery)
 	require.Equal(t, "runner-1", gotRunnerRoute)
@@ -1334,6 +1331,7 @@ func TestLiveRunnerSingleShotProxyOnchainReturnsPaymentChallenge(t *testing.T) {
 	require.Equal(t, http.StatusPaymentRequired, w.Code)
 	challenge, oInfo := decodeLiveRunnerPaymentChallenge(t, w.Body.Bytes())
 	require.NotEmpty(t, challenge.ManifestID)
+	require.Equal(t, int64(5000), challenge.PaymentIntervalMs)
 	require.Equal(t, int64(10), oInfo.GetPriceInfo().GetPricePerUnit())
 	require.Equal(t, int64(1), oInfo.GetPriceInfo().GetPixelsPerUnit())
 }

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -493,7 +493,7 @@ func (h *lphttp) RefreshPayment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	data, err := marshalLivePaymentChallengeResponse(oInfo)
+	data, err := marshalLivePaymentChallengeResponse(oInfo, h.node.LivePaymentInterval)
 	if err != nil {
 		respondJsonError(ctx, w, err, http.StatusInternalServerError)
 		return


### PR DESCRIPTION
Follow-ups on top of the single-shot live runner payments work, targeting this branch so they roll into the PR.

## Commits

1. **server: simplify single-shot session release lifecycle.** Tidy `ProxyLiveRunnerSingleShot`: drop the `reservedID`/`reservedIDInput` split, release the reserved session on return, and remove the redundant session/manifest recheck (`ReserveSession` returns the supplied id verbatim or a 409, so the recheck could never fire).
2. **server: address single-shot payment review feedback:**
   - Drop the `ModifyResponse` block (`Livepeer-Session-Id/Control/Payment` response headers). WebSocket clients can't read upgrade response headers, and SSE/HTTP clients derive the session-scoped payment URL from the 402 challenge (`manifest_id` + `orchestrator`), so the headers were redundant. Request-side `Rewrite` headers to the runner are unchanged.
   - Surface `payment_interval_ms` in the 402 challenge (the orchestrator's debit interval) so a client can size its top-ups instead of guessing. Returned on both the persistent and single-shot challenge paths via `runnerChallenge`, and asserted in the single-shot challenge test.
   - Rename `startLiveRunnerSessionPaymentMonitor` to `startLiveRunnerSessionPaymentLoop` (matches the `startAutoConvertLoop` convention; `monitorCtx` to `loopCtx`).
   - Type the loop's `manifestID` as `core.ManifestID` instead of a bare string, converting at the single use site.
3. **server: bound single-shot payment loop to the request context.** The metering loop's lifetime is now the ctx the caller passes: single-shot passes the request ctx (the loop stops when the request returns), persistent passes `context.WithoutCancel(ctx)` (the loop outlives the reservation and stops on session release). Matches the `startAutoConvertLoop` convention: the caller owns the lifetime via the context.

## Notes

- A separate billing-hardening item (enforce payment failures and avoid a one-interval post-release overcharge in `LivePaymentProcessor.processOne`) is tracked in livepeer/go-livepeer#3982, since it applies to both persistent and single-shot.

## Testing

`go build ./server/...` clean; `go test ./server -run TestLiveRunner` passes.
